### PR TITLE
Updated validation to treat minor_version as mandatory field to align…

### DIFF
--- a/src/main/java/uk/co/onsdigital/discovery/dao/DatasetDAOImpl.java
+++ b/src/main/java/uk/co/onsdigital/discovery/dao/DatasetDAOImpl.java
@@ -124,13 +124,11 @@ public class DatasetDAOImpl implements DatasetDAO {
     @Override
     public void createOrUpdateMetadata(DatasetMetadata form) throws MetadataEditorException {
         try {
-            int minorVersion = isEmpty(form.getMinorVersion()) ? 0 : Integer.parseInt(form.getMinorVersion());
-
             SqlParameterSource sqlParameterSource = createParameterSource.apply(
                     new NamedParam.ListBuilder()
                             .addParam(JSON_METADATA_FIELD, form.getJsonMetadata())
                             .addParam(MAJOR_VERSION_FIELD, Integer.parseInt(form.getMajorVersion()))
-                            .addParam(MINOR_VERSION_FIELD, minorVersion)
+                            .addParam(MINOR_VERSION_FIELD, Integer.parseInt(form.getMinorVersion()))
                             .addParam(REVISION_NOTES_FIELD, form.getRevisionNotes())
                             .addParam(REVISION_REASON_FIELD, form.getRevisionReason())
                             .addParam(DATASET_ID_FIELD, UUID.fromString(form.getDatasetId()))

--- a/src/main/java/uk/co/onsdigital/discovery/validation/MetadataValidator.java
+++ b/src/main/java/uk/co/onsdigital/discovery/validation/MetadataValidator.java
@@ -25,6 +25,7 @@ public class MetadataValidator implements Validator {
     static final String MAJOR_VERSION_EMPTY = "dataset.major.version.empty";
 
     static final String MINOR_VERSION_NOT_NUMBER = "dataset.minor.version.number.format.ex";
+    static final String MINOR_VERSION_EMPTY = "dataset.minor.version.empty";
 
     static final String JSON_METADATA_FIELD_NAME = "jsonMetadata";
     static final String DATASET_ID_FIELD_NAME = "datasetId";
@@ -86,6 +87,10 @@ public class MetadataValidator implements Validator {
     }
 
     private void validateMinorVersion(Errors errors, DatasetMetadata metadata) {
+        if (isEmpty(metadata.getMinorVersion())) {
+            errors.rejectValue(MINOR_VERSION_FIELD_NAME, MINOR_VERSION_EMPTY);
+        }
+
         if (isNotEmpty(metadata.getMinorVersion())) {
             try {
                 Integer.parseInt(metadata.getMinorVersion());

--- a/src/main/resources/messages/messages.properties
+++ b/src/main/resources/messages/messages.properties
@@ -5,6 +5,7 @@ dataset.id.invalid=* Invalid DatsetID.
 dataset.major.version.number.format.ex=* Major Version must be a number.
 dataset.major.version.empty=* Major version is mandatory.
 dataset.minor.version.number.format.ex=* Minor Version must be a number
+dataset.minor.version.empty=* Minor version is mandatory.
 
 # Field labels.
 dataset.id.field.label=DatasetID:

--- a/src/main/resources/messages/messages_en.properties
+++ b/src/main/resources/messages/messages_en.properties
@@ -5,6 +5,7 @@ dataset.id.invalid=* Invalid DatsetID.
 dataset.major.version.number.format.ex=* Major Version must be a number.
 dataset.major.version.empty=* Major version is mandatory.
 dataset.minor.version.number.format.ex=* Minor Version must be a number
+dataset.minor.version.empty=* Minor version is mandatory.
 
 # Field labels.
 dataset.id.field.label=DatasetID:

--- a/src/main/resources/static/js/metadata-form.js
+++ b/src/main/resources/static/js/metadata-form.js
@@ -12,6 +12,7 @@ $(document).ready(function() {
                 $("#js-json-validation-err").hide();
                 $("#major-version-err").hide();
                 $("#minor-version-err").hide();
+                $("#ss-validation-error").hide();
             } catch (e) {
                 if ($("#ss-validation-error").is(":visible")) {
                     // do nothing.

--- a/src/test/java/uk/co/onsdigital/discovery/validation/MetadataValidatorTest.java
+++ b/src/test/java/uk/co/onsdigital/discovery/validation/MetadataValidatorTest.java
@@ -20,6 +20,7 @@ import static uk.co.onsdigital.discovery.validation.MetadataValidator.JSON_METAD
 import static uk.co.onsdigital.discovery.validation.MetadataValidator.MAJOR_VERSION_EMPTY;
 import static uk.co.onsdigital.discovery.validation.MetadataValidator.MAJOR_VERSION_FIELD_NAME;
 import static uk.co.onsdigital.discovery.validation.MetadataValidator.MAJOR_VERSION_NOT_NUMBER;
+import static uk.co.onsdigital.discovery.validation.MetadataValidator.MINOR_VERSION_EMPTY;
 import static uk.co.onsdigital.discovery.validation.MetadataValidator.MINOR_VERSION_FIELD_NAME;
 import static uk.co.onsdigital.discovery.validation.MetadataValidator.MINOR_VERSION_NOT_NUMBER;
 
@@ -79,6 +80,15 @@ public class MetadataValidatorTest {
         validator.validate(datasetMetadata, mockBindingResult);
 
         verify(mockBindingResult, times(1)).rejectValue(MAJOR_VERSION_FIELD_NAME, MAJOR_VERSION_NOT_NUMBER);
+    }
+
+    @Test
+    public void shouldRejectIfMinorVersionEmpty() {
+        datasetMetadata = new DatasetMetadata()
+                .setDatasetId(UUID.randomUUID().toString())
+                .setMajorVersion("1");
+        validator.validate(datasetMetadata, mockBindingResult);
+        verify(mockBindingResult, times(1)).rejectValue(MINOR_VERSION_FIELD_NAME, MINOR_VERSION_EMPTY);
     }
 
     @Test


### PR DESCRIPTION
… with latest DB model.

### What

Updated validation to make minor_version mandatory to align with latest DB model.

### How to review

You should now be forced to provide a minor version before you can submit metadata.

### Who can review

@CarlHembrough @YetAnotherMatt @NeilMadden @fenallen 
